### PR TITLE
[bug] Fix XCode Cloud build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,18 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
-// Intructions: https://code.visualstudio.com/docs/devcontainers/create-dev-container
+// Instructions: https://code.visualstudio.com/docs/devcontainers/create-dev-container
 {
-	"name": "Node.js & TypeScript",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install -g @ionic/cli@7.2.0"
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  "name": "Node.js & TypeScript",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "npm install -g @ionic/cli@7.2.0"
+  // Configure tool-specific properties.
+  // "customizations": {},
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/ios/App/ci_scripts/ci_post_clone.sh
+++ b/ios/App/ci_scripts/ci_post_clone.sh
@@ -1,22 +1,33 @@
- #!/bin/zsh
+#!/bin/zsh
 
- # fail if any command fails
+# fail if any command fails
 
- echo "🧩 Stage: Post-clone is activated .... "
+echo "🧩 Stage: Post-clone is activated .... "
 
- set -e
- # debug log
- set -x
+set -e
+# debug log
+set -x
 
- # Install dependencies using Homebrew. This is MUST! Do not delete.
- brew install node yarn cocoapods fastlane
+export HOMEBREW_NO_INSTALL_CLEANUP=TRUE
 
- # Install yarn and pods dependencies.
- # If you're using Flutter or Swift 
- # just install pods by "pod install" command 
- ls && cd .. && yarn && pod install
+# Install dependencies using Homebrew. This is MUST! Do not delete.
+brew install node yarn cocoapods fastlane
+brew install node@18
+brew link --overwrite node@18
 
- echo "🎯 Stage: Post-clone is done .... "
+# Install yarn and pods dependencies.
+# If you're using Flutter or Swift 
+# just install pods by "pod install" command 
+ls && cd .. && yarn && pod install
 
- exit 0
- 
+# Install dependencies with NPM
+npm config set maxsockets 3
+npm ci
+# or `pnpm install --frozen-lockfile` or `yarn install --frozen-lockfile` or bun install
+npm run build
+# or npm run build
+npm run sync:ios
+
+echo "🎯 Stage: Post-clone is done .... "
+
+exit 0

--- a/ios/App/ci_scripts/ci_post_xcodebuild.sh
+++ b/ios/App/ci_scripts/ci_post_xcodebuild.sh
@@ -1,10 +1,9 @@
- #!/bin/zsh
+#!/bin/zsh
 
- echo "🧩 Stage: POST-Xcode Build is activated .... "
+echo "🧩 Stage: POST-Xcode Build is activated .... "
 
- # You can add additional scripts here...
+# You can add additional scripts here...
 
- echo "🎯 Stage: POST-Xcode Build is DONE .... "
+echo "🎯 Stage: POST-Xcode Build is DONE .... "
 
- exit 0
- 
+exit 0

--- a/ios/App/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/App/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,10 +1,9 @@
- #!/bin/zsh
+#!/bin/zsh
 
- echo "🧩 Stage: PRE-Xcode Build is activated .... "
+echo "🧩 Stage: PRE-Xcode Build is activated .... "
 
- # You can add additional scripts here...
+# You can add additional scripts here...
 
- echo "🎯 Stage: PRE-Xcode Build is DONE .... "
+echo "🎯 Stage: PRE-Xcode Build is DONE .... "
 
- exit 0
- 
+exit 0

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc && vite build",
+    "sync:ios": "cap sync ios",
     "preview": "vite preview",
     "test:e2e": "cypress run",
     "test:unit": "vitest",


### PR DESCRIPTION
## Problem

The current **XCode Cloud** build fails because the **Ionic** build commands do not get executed there and assets are missing, including three configuration files.

The following link has instructions on how to fix this: https://capgo.app/blog/how-to-build-capacitor-app-in-xcode-cloud/

## Solution

I have updated the script and made the post build code an executable file. It looks like the `ci_scripts` could actually be added to the workflow in XCode Cloud, but I was not able to test this out as part of this PR.

The issues with the Ionic assets were fixed in this PR. The build, however, is still broken as XCode Cloud is not finding the provisioning profile and signing certificate. This is work for a different PR.